### PR TITLE
Fix for new jb

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@jbrowse/core": "^1.0.4"
+    "@jbrowse/core": "^1.3.0"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.4",

--- a/src/QuantitativeSequenceAdapter/QuantitativeSequenceAdapter.ts
+++ b/src/QuantitativeSequenceAdapter/QuantitativeSequenceAdapter.ts
@@ -24,30 +24,31 @@ export default class QuantitativeSequenceAdapter extends BaseFeatureDataAdapter 
   private sequenceAdapter: any
   private wiggleAdapter: any
 
-  public constructor(
-    config: AnyConfigurationModel,
-    getSubAdapter?: getSubAdapterType,
-  ) {
-    super(config)
-
-    const sequenceAdapterConfig = readConfObject(config, 'sequenceAdapter')
-    if (sequenceAdapterConfig && getSubAdapter) {
-      const { dataAdapter } = getSubAdapter(sequenceAdapterConfig)
+  private async setup() {
+    //@ts-ignore
+    const sequenceAdapterConfig = readConfObject(this.config, 'sequenceAdapter')
+    if (sequenceAdapterConfig) {
+      //@ts-ignore
+      const { dataAdapter } = await this.getSubAdapter(sequenceAdapterConfig)
       this.sequenceAdapter = dataAdapter as BaseFeatureDataAdapter
     }
 
-    const wiggleAdapterConfig = readConfObject(config, 'wiggleAdapter')
-    if (wiggleAdapterConfig && getSubAdapter) {
-      const { dataAdapter } = getSubAdapter(wiggleAdapterConfig)
+    //@ts-ignore
+    const wiggleAdapterConfig = readConfObject(this.config, 'wiggleAdapter')
+    if (wiggleAdapterConfig) {
+      //@ts-ignore
+      const { dataAdapter } = await this.getSubAdapter(wiggleAdapterConfig)
       this.wiggleAdapter = dataAdapter as BaseFeatureDataAdapter
     }
   }
 
   public async getRefNames(opts?: BaseOptions) {
+    await this.setup()
     return this.wiggleAdapter.getRefNames(opts)
   }
 
   public async getGlobalStats(opts?: BaseOptions) {
+    await this.setup()
     return this.wiggleAdapter.getGlobalStats(opts)
   }
 


### PR DESCRIPTION
This is a quick fix for running under the latest jbrowse

The process of getting a subadapter can be async so it needs to run like this

This isn't a perfect scheme (some ts-ignores, some relying on behavior of getRefNames called first) but it is a quick fix

CC @elliothershberg 